### PR TITLE
ci: harden release pipeline and add Trivy scanning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,33 +2,85 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*"
+      - "v*.*.*" # build on semver tags
+    branches:
+      - master # push 'latest' on default branch
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: fnayou/podcastify
 
 jobs:
   docker:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: read
+      packages: write
+      id-token: write # SBOM/provenance
+      attestations: write # GitHub attestations
+      security-events: write # upload SARIF to code scanning
+
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-      - uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-      - uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=moby/buildkit:buildx-stable-1
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
+          registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Extract tag
+      # Works for tag or branch builds
+      - name: Extract version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+            IS_PRERELEASE="$([[ "${GITHUB_REF_NAME}" == *-* ]] && echo true || echo false)"
+          else
+            VERSION="$(date -u +%Y%m%d)-${GITHUB_SHA::7}"
+            IS_PRERELEASE=false
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "is_prerelease=${IS_PRERELEASE}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker meta
         id: meta
-        run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag builds (vX.Y.Z, X.Y)
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            # Push 'latest' on default branch OR stable tag (no '-')
+            type=raw,value=latest,enable=${{ github.ref_type == 'branch' && github.ref_name == 'master' }}
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+          labels: |
+            org.opencontainers.image.title=podcastify
+            org.opencontainers.image.description=Self-hosted podcast RSS generator (Caddy+Python)
+            org.opencontainers.image.licenses=MIT
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.meta.outputs.created }}
 
       - name: Build & Push
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -37,13 +89,83 @@ jobs:
           push: true
           sbom: true
           provenance: true
-          tags: |
-            yourname/podcastify:latest
-            yourname/podcastify:${{ steps.meta.outputs.VERSION }}
-          labels: |
-            org.opencontainers.image.title=PodCastify
-            org.opencontainers.image.description=Create private podcast feeds from your own MP3s with zero fuss.
-            org.opencontainers.image.licenses=MIT
-            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-            org.opencontainers.image.version=${{ steps.meta.outputs.VERSION }}
-            org.opencontainers.image.authors=Aymen FNAYOU <fnayou.aymen@gmail.com>
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_DATE=${{ steps.meta.outputs.created }}
+            VCS_REF=${{ github.sha }}
+
+      # --- Security scanning (Trivy) ---
+
+      # Fail CI on CRITICAL vulns only; scan the pushed image by immutable digest
+      - name: Run Trivy vulnerability scanner (fail on CRITICAL)
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          format: "table"
+          vuln-type: "os,library"
+          severity: "CRITICAL"
+          ignore-unfixed: true
+          exit-code: "1"
+          hide-progress: true
+
+      # Generate SARIF for the Security tab (does not fail the job)
+      - name: Run Trivy (SARIF)
+        if: always()
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          ignore-unfixed: true
+          hide-progress: true
+
+      - name: Upload Trivy SARIF to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      # Optional: attest the pushed digest
+      - name: Generate artifact attestation
+        if: github.repository_owner == 'fnayou'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+  # Optional: GitHub Release for tag builds
+  release:
+    runs-on: ubuntu-latest
+    needs: docker
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          release_name: Release ${{ github.ref_name }}
+          body: |
+            ## Docker Image
+            ```
+            docker pull ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+            ```
+            ## Notes
+            - Multi-arch: linux/amd64, linux/arm64
+            - SBOM and provenance attached
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Create private podcast feeds from your own MP3s with minimal setup. Drop MP3s in
 - Simple layout: `./podcasts/*.yaml` for configs, `./public/<name>/` for media and images.
 - Auto-discovery of episodes if you omit the `episodes:` list.
 - MP3 duration extraction via `ffprobe` (falls back gracefully).
-- iTunes fields: author, owner, subtitle, summary, explicit, categories, episode types, seasons, and more.
+- iTunes fields: author, owner, subtitle, summary, explicit, categories, episode types, seasons.
 - Clean XML: stable GUIDs (SHA-1), configurable language, empty tags rather than empty CDATA.
 - Single container image: Caddy (static hosting) + Python generator.
 - Developer-friendly Taskfile with commands like `task up`, `task generate`, `task logs`.
@@ -159,6 +159,36 @@ The image ships with a Caddyfile that uses an environment variable for the port 
   }
 }
 ```
+
+---
+
+## Security hardening
+
+The image runs fine as-is. For additional defense-in-depth, you can apply these Compose settings with **v1.0.0 and later** without changing the image:
+
+```yaml
+services:
+  podcastify:
+    # ... your existing config ...
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: ["ALL"]
+```
+
+These settings make the root filesystem read-only (your mounted `public/` and `podcasts/` remain writable), prevent privilege escalation, and drop Linux capabilities (the app listens on high port `${PORT}` so none are needed).
+
+If you later publish an image that runs as a non-root user by default (for example `v1.0.1+`), you can also add:
+
+```yaml
+services:
+  podcastify:
+    user: "10001:10001"
+```
+
+and keep the same hardening flags above.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
 services:
   podcastify:
+    # image: fnayou/podcastify:v1.0.0  # update version
     build:
       context: .
       dockerfile: docker/podcastify/Dockerfile
-    container_name: podcastify
+    user: "10001:10001"
+    read_only: true
+    tmpfs:
+      - /tmp
+    security_opt:
+      - no-new-privileges:true
+    cap_drop: ["ALL"]
     ports:
       - "${HOST_PORT:-8080}:${PORT:-8080}"
     environment:

--- a/docker/podcastify/Dockerfile
+++ b/docker/podcastify/Dockerfile
@@ -1,40 +1,28 @@
-# Combined image: Python (generator) + Caddy (static server)
-FROM python:3.12-alpine
-
-LABEL org.opencontainers.image.authors="Aymen FNAYOU <fnayou.aymen@gmail.com>"
-LABEL org.opencontainers.image.title="PodCastify"
-LABEL org.opencontainers.image.description="Create private podcast feeds from your own MP3s with zero fuss."
-LABEL org.opencontainers.image.source="https://github.com/fnayou/podcastify"
-
-# system packages
-RUN apk add --no-cache caddy ffmpeg
-
-WORKDIR /app
-
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt || pip install --no-cache-dir PyYAML
+FROM python:3.12-alpine3.21
 
 
-# copy generator from project root into image
+RUN apk add --no-cache --update caddy ffmpeg \
+  && apk upgrade --no-cache
+
+RUN addgroup -S app && adduser -S -G app -u 10001 app \
+  && mkdir -p /app/public /app/podcasts /config /data \
+  && chown -R app:app /app /config /data
+
+
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
 COPY app.py /app/app.py
-
-# copy caddy config from repo
 COPY docker/podcastify/Caddyfile /etc/caddy/Caddyfile
+COPY docker/podcastify/entrypoint.sh /entrypoint.sh
+COPY docker/podcastify/supervisord.conf /etc/supervisord.conf
 
-# prepare directories
-RUN mkdir -p /app/public /app/podcasts
-
-# environment defaults
 ENV PORT=8080 \
-  PUBLIC_BASE_URL=http://localhost:8080 \
   PODCASTS_ROOT=/app/podcasts \
   PUBLIC_ROOT=/app/public \
   RUN_ON_START=true \
   PUBLISH_XML=true
-# EXPOSE 8080  # (optional, informational only)
 
-# simple entrypoint: optionally run generator, then start caddy
-COPY docker/podcastify/entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-
+USER app
+EXPOSE 8080
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Tasks

- [x] Build multi-arch (amd64/arm64) with SBOM+provenance
- [x] tag latest on master and stable tags
- [x] scan pushed image by digest with Trivy (fail on CRITICAL, upload SARIF).
- [x] run as non-root and package upgrades in Dockerfile, Compose hardening hints
- [x] README updates.