### PR TITLE
ci(release): build on tags only, add PR CI + Trivy, fix attestation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
-# Host port → reach at http://localhost:1234
-HOST_PORT=1234
+# Host vs container ports
+HOST_PORT=8080
+SERVICE_PORT=8080
 
-# Container listen port (matches Caddy’s :{$PORT})
-PORT=8080
+# Public base URL used inside the generated RSS
+PUBLIC_BASE_URL=http://localhost:${HOST_PORT}
 
-# The base URL used inside the generated XML (match your host + port/domain)
-PUBLIC_BASE_URL=http://localhost:1234
-# For production:
-# PUBLIC_BASE_URL=https://podcasts.domain-name.tld
+# In-container paths (don’t change unless you know why)
+PODCASTS_ROOT=/app/podcasts
+PUBLIC_ROOT=/app/public
+
+# Generator behavior
+RUN_ON_START=true
+PUBLISH_XML=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,10 @@ name: release
 on:
   push:
     tags:
-      - "v*.*.*" # build on semver tags
+      - "v*.*.*" # build/push on semver tags only
+  pull_request:
     branches:
-      - master # push 'latest' on default branch
+      - master # run CI on PRs; build locally, no push
 
 env:
   REGISTRY: docker.io
@@ -22,6 +23,7 @@ jobs:
       id-token: write # SBOM/provenance
       attestations: write # GitHub attestations
       security-events: write # upload SARIF to code scanning
+      pull-requests: write # needed so Scout can post PR comments
 
     steps:
       - name: Checkout
@@ -35,14 +37,16 @@ jobs:
         with:
           driver-opts: image=moby/buildkit:buildx-stable-1
 
+      # Login only on tag pushes (PRs don't have secrets from forks)
       - name: Login to Docker Hub
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Works for tag or branch builds
+      # Version info (nice labels; for PRs we create a synthetic version)
       - name: Extract version
         id: version
         shell: bash
@@ -63,24 +67,25 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            # Tag builds (vX.Y.Z, X.Y)
+            # For tag builds: vX.Y.Z, X.Y
             type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            # Push 'latest' on default branch OR stable tag (no '-')
-            type=raw,value=latest,enable=${{ github.ref_type == 'branch' && github.ref_name == 'master' }}
+            # Update 'latest' only for stable tags (no pre-release suffix)
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
           labels: |
             org.opencontainers.image.title=podcastify
-            org.opencontainers.image.description=Self-hosted podcast RSS generator (Caddy+Python)
+            org.opencontainers.image.description=tiny self-hosted podcast RSS generator. Create private podcast feeds from your own MP3s with zero fuss.
             org.opencontainers.image.licenses=MIT
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ steps.version.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.created=${{ steps.meta.outputs.created }}
 
-      - name: Build & Push
-        id: build
+      # Build & push on tag pushes (multi-arch)
+      - name: Build & Push (tag)
+        id: build-push
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -98,13 +103,70 @@ jobs:
             BUILD_DATE=${{ steps.meta.outputs.created }}
             VCS_REF=${{ github.sha }}
 
-      # --- Security scanning (Trivy) ---
+      # PR builds: build locally (no push), single-arch for speed
+      - name: Build (PR, no push)
+        id: build-pr
+        if: github.event_name == 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/podcastify/Dockerfile
+          platforms: linux/amd64
+          load: true
+          push: false
+          tags: local/podcastify:${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            BUILD_DATE=${{ steps.meta.outputs.created }}
+            VCS_REF=${{ github.sha }}
 
-      # Fail CI on CRITICAL vulns only; scan the pushed image by immutable digest
-      - name: Run Trivy vulnerability scanner (fail on CRITICAL)
+      # ---------------- Docker Scout on PRs ----------------
+      # Skip forked PRs (no secrets available)
+      - name: Note about forked PRs (no Docker Hub secrets)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
+        run: echo "Skipping Docker Scout on forked PRs (no secrets). Trivy still runs."
+
+      # Login + scan only for PRs from same repo
+      - name: Login to Docker Hub (PR, same-repo only)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker Scout (PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        id: docker-scout
+        continue-on-error: true
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: local://local/podcastify:${{ github.sha }}
+          only-severities: critical,high
+          only-fixed: true
+          summary: true
+          write-comment: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sarif-file: docker-scout.sarif
+
+      - name: Upload SARIF (Scout, PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: docker-scout.sarif
+
+      # ---------------- Security scanning (Trivy) ----------------
+
+      # Tag pushes: scan the pushed image by immutable digest (fail on CRITICAL)
+      - name: Trivy scan (push, fail on CRITICAL)
+        if: github.event_name == 'push'
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-push.outputs.digest }}"
           format: "table"
           vuln-type: "os,library"
           severity: "CRITICAL"
@@ -112,12 +174,26 @@ jobs:
           exit-code: "1"
           hide-progress: true
 
-      # Generate SARIF for the Security tab (does not fail the job)
-      - name: Run Trivy (SARIF)
-        if: always()
+      # PRs: scan the local image (non-blocking)
+      - name: Trivy scan (PR, non-blocking)
+        if: github.event_name == 'pull_request'
         uses: aquasecurity/trivy-action@0.24.0
         with:
-          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}"
+          image-ref: "local/podcastify:${{ github.sha }}"
+          format: "table"
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH"
+          ignore-unfixed: true
+          exit-code: "0"
+          hide-progress: true
+
+      # SARIF for tag pushes
+      - name: Trivy SARIF (push)
+        id: sarif-push
+        if: github.event_name == 'push'
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-push.outputs.digest }}"
           format: "sarif"
           output: "trivy-results.sarif"
           vuln-type: "os,library"
@@ -125,19 +201,39 @@ jobs:
           ignore-unfixed: true
           hide-progress: true
 
-      - name: Upload Trivy SARIF to GitHub Security
-        if: always()
+      - name: Upload SARIF (Trivy, push)
+        if: steps.sarif-push.outcome == 'success'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: "trivy-results.sarif"
 
-      # Optional: attest the pushed digest
+      # SARIF for PRs
+      - name: Trivy SARIF (PR)
+        id: sarif-pr
+        if: github.event_name == 'pull_request'
+        uses: aquasecurity/trivy-action@0.24.0
+        with:
+          image-ref: "local/podcastify:${{ github.sha }}"
+          format: "sarif"
+          output: "trivy-results.sarif"
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW"
+          ignore-unfixed: true
+          hide-progress: true
+
+      - name: Upload SARIF (Trivy, PR)
+        if: steps.sarif-pr.outcome == 'success'
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: "trivy-results.sarif"
+
+      # Attest only for tag builds with fully-qualified subject-name
       - name: Generate artifact attestation
-        if: github.repository_owner == 'fnayou'
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         uses: actions/attest-build-provenance@v1
         with:
-          subject-name: ${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.build.outputs.digest }}
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
   # Optional: GitHub Release for tag builds

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,22 @@
 services:
   podcastify:
-    # image: fnayou/podcastify:v1.0.0  # update version
     build:
       context: .
       dockerfile: docker/podcastify/Dockerfile
-    user: "10001:10001"
-    read_only: true
-    tmpfs:
-      - /tmp
-    security_opt:
-      - no-new-privileges:true
-    cap_drop: ["ALL"]
+
+    restart: unless-stopped
+
     ports:
-      - "${HOST_PORT:-8080}:${PORT:-8080}"
+      - "${HOST_PORT:-8080}:${SERVICE_PORT:-8080}"
+
     environment:
-      - PORT=${PORT:-8080}
+      - SERVICE_PORT=${SERVICE_PORT:-8080}
       - PUBLIC_BASE_URL=${PUBLIC_BASE_URL:-http://localhost:${HOST_PORT:-8080}}
-      - PODCASTS_ROOT=/app/podcasts
-      - PUBLIC_ROOT=/app/public
+      - PODCASTS_ROOT=${PODCASTS_ROOT:-/app/podcasts}
+      - PUBLIC_ROOT=${PUBLIC_ROOT:-/app/public}
       - RUN_ON_START=${RUN_ON_START:-true}
       - PUBLISH_XML=${PUBLISH_XML:-true}
+
     volumes:
-      - ./public:/app/public
-      - ./podcasts:/app/podcasts
-    restart: unless-stopped
+      - ./public:/app/public:rw
+      - ./podcasts:/app/podcasts:rw

--- a/docker/podcastify/Caddyfile
+++ b/docker/podcastify/Caddyfile
@@ -1,11 +1,18 @@
-:{$PORT} {
+:{$SERVICE_PORT} {
   root * /app/public
   encode gzip
   header Access-Control-Allow-Origin "*"
 
+  @rss path *.xml
+  header @rss Content-Type "application/rss+xml; charset=utf-8"
+  header @rss Cache-Control "no-cache"
+
+  @assets path *.mp3 *.jpg *.jpeg *.png *.webp
+  header @assets Cache-Control "public, max-age=31536000, immutable"
+
   file_server {
     browse
-    hide .gitkeep
+    hide .*
   }
 
   log {

--- a/docker/podcastify/Dockerfile
+++ b/docker/podcastify/Dockerfile
@@ -1,28 +1,31 @@
-FROM python:3.12-alpine3.21
+FROM python:3.12-alpine3.22
 
+# System deps (keep small)
+RUN apk add --no-cache caddy ffmpeg supervisor tini ca-certificates
 
-RUN apk add --no-cache --update caddy ffmpeg \
-  && apk upgrade --no-cache
+WORKDIR /app
 
-RUN addgroup -S app && adduser -S -G app -u 10001 app \
-  && mkdir -p /app/public /app/podcasts /config /data \
-  && chown -R app:app /app /config /data
+# Python deps
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-
-COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
-
-COPY app.py /app/app.py
-COPY docker/podcastify/Caddyfile /etc/caddy/Caddyfile
-COPY docker/podcastify/entrypoint.sh /entrypoint.sh
+# App + configs
+COPY app.py /app/
+COPY docker/podcastify/Caddyfile        /etc/caddy/Caddyfile
 COPY docker/podcastify/supervisord.conf /etc/supervisord.conf
+COPY docker/podcastify/entrypoint.sh    /entrypoint.sh
 
-ENV PORT=8080 \
+# Ensure entrypoint is executable and LF line endings
+RUN chmod 0755 /entrypoint.sh && sed -i 's/\r$//' /entrypoint.sh
+
+# Defaults (override via compose/.env)
+ENV SERVICE_PORT=8080 \
+  PUBLIC_BASE_URL=http://localhost:8080 \
   PODCASTS_ROOT=/app/podcasts \
   PUBLIC_ROOT=/app/public \
   RUN_ON_START=true \
   PUBLISH_XML=true
 
-USER app
 EXPOSE 8080
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/podcastify/entrypoint.sh
+++ b/docker/podcastify/entrypoint.sh
@@ -10,5 +10,6 @@ if [ "${RUN_ON_START:-true}" = "true" ]; then
   fi
 fi
 
-echo "🌐 Starting Caddy on :{$PORT:8080}"
-exec caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
+echo "🌐 Starting Caddy on : $PUBLIC_BASE_URL"
+
+exec /usr/bin/supervisord -c /etc/supervisord.conf

--- a/docker/podcastify/supervisord.conf
+++ b/docker/podcastify/supervisord.conf
@@ -1,14 +1,15 @@
 [supervisord]
 nodaemon=true
-logfile=/dev/null
 pidfile=/tmp/supervisord.pid
-childlogdir=/var/log/supervisor
 
 [program:caddy]
-command=/usr/bin/caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-stderr_logfile=/dev/fd/2
-stderr_logfile_maxbytes=0
+; run through sh so PATH/env are honored
+command=/bin/sh -lc 'caddy run --config /etc/caddy/Caddyfile --adapter caddyfile'
+autostart=true
 autorestart=true
-startretries=3
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+; make sure PATH includes where apk installs caddy
+environment=PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
## Tasks

- [x] release.yml: conservative policy (semver tags only),
- [x] update 'latest' only on stable tags;
- [x] add pull_request CI (local build, no push);
- [x] multi-arch build+push on tag;
- [x] Trivy scans (digest-based on push, local on PR) with SARIF upload;
- [x] fix provenance attestation using fully-qualified subject-name (docker.io/fnayou/podcastify) and run only on tag builds;
- [x] login gated to push events.
